### PR TITLE
Fixed the Redundant Popup on Window Load

### DIFF
--- a/src/lab/diff.php
+++ b/src/lab/diff.php
@@ -188,6 +188,7 @@ $(".start").css("top",pos_y*281/num_blocks +document.getElementById("Layer-4").o
 
 
 <script type="text/javascript">
+	$("html").css("display","none");
 function doTransform(){
 
     	
@@ -359,7 +360,8 @@ $("#sliderContent").replaceWith('      <div id="sliderContent" class="ui-corner-
   imageWidth: 32,
   });
   toggleMosaic();
-    $("#choice").buttonset();
+  $("#Mosaic").css("display","none");
+  $("#choice").buttonset();
   $("#choice").button("refresh");
   $(".advanced").hide();
   
@@ -408,8 +410,6 @@ $("#sliderContent").replaceWith('      <div id="sliderContent" class="ui-corner-
 	?>
 });
 
-
-
 </script>
 </head>
 
@@ -421,7 +421,7 @@ $("#sliderContent").replaceWith('      <div id="sliderContent" class="ui-corner-
     
 
     <!-- This is 'Mosaic_jpg' -->
-    <div id="Mosaic" class="Mosaic_jpg"  >
+    <div id="Mosaic" class="Mosaic_jpg">
       <img src="images/Mosaicdiff.png" width="513" height="513" alt="Mosaic" /></div>
 
     <!-- This is 'Thumbnails_jpg' -->
@@ -602,6 +602,10 @@ $("#sliderContent").replaceWith('      <div id="sliderContent" class="ui-corner-
 <input type="radio" name="type2" value="8" />8 connectivity<br/>
 </div>
 </div>
+
+	<script type="text/javascript">
+		$("html").css("display","block");
+	</script>
 
 </body>
 


### PR DESCRIPTION
References Issue #108 . The fix displays the HTML only once the entire page has loaded. Toggling the initial state of #mosaic to `display:none` doesn't work as the call to toggleMosaic() makes the mosaic permanent.