### PR TITLE
Reference tab uncommented

### DIFF
--- a/src/lab/point.php
+++ b/src/lab/point.php
@@ -504,8 +504,8 @@ $("button3","#zoom").button();
 			   </ul>
 
 </li>
-<!--<li><a href="references.php?exp=point" target="_self" >References</a>
-</li>-->
+<li><a href="references.php?exp=point" target="_self" >References</a>
+</li>
 <li><a href="summary.php" target="_blank" >Summary</a>
 </li>
 </ul>


### PR DESCRIPTION
The missing "References" button was due to the list item being commented in the php file. Uncommenting it fixes the issue.